### PR TITLE
Fix server WebApplication reference and remove invalid MudBlazor package

### DIFF
--- a/ChatVerse/ChatVerse.Client/ChatVerse.Client.csproj
+++ b/ChatVerse/ChatVerse.Client/ChatVerse.Client.csproj
@@ -6,7 +6,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
     <PackageReference Include="MudBlazor" Version="7.0.0" />
-    <PackageReference Include="MudBlazor.Services" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../ChatVerse.Shared/ChatVerse.Shared.csproj" />

--- a/ChatVerse/ChatVerse.Server/Program.cs
+++ b/ChatVerse/ChatVerse.Server/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.AspNetCore.Builder;
 using Serilog;
 using System.Text;
 


### PR DESCRIPTION
## Summary
- fix server Program.cs by adding missing WebApplication using directive
- remove nonexistent MudBlazor.Services package to allow client restore

## Testing
- `dotnet build ChatVerse/ChatVerse.Server -v minimal` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68910b73b0048331803ca1c2e3926a0d